### PR TITLE
feat: add path filter to the Azure pipeline configurations

### DIFF
--- a/catalogue/pipelines/azure-pipelines.yaml
+++ b/catalogue/pipelines/azure-pipelines.yaml
@@ -1,7 +1,14 @@
 name: craftista_$(serviceName)_$(Date:yyyyMMdd)_$(Rev:.r)
 
 trigger:
-- main
+  branches:
+    include:
+      - main
+  paths:
+    include:
+      - catalogue/**
+
+pr: none
 
 resources:
   repositories:

--- a/recommendation/pipelines/azure-pipelines.yaml
+++ b/recommendation/pipelines/azure-pipelines.yaml
@@ -1,7 +1,14 @@
 name: craftista_$(serviceName)_$(Date:yyyyMMdd)_$(Rev:.r)
 
 trigger:
-- main
+  branches:
+    include:
+      - main
+  paths:
+    include:
+      - recommendation/**
+
+pr: none
 
 resources:
   repositories:

--- a/voting/pipelines/azure-pipelines.yaml
+++ b/voting/pipelines/azure-pipelines.yaml
@@ -1,7 +1,14 @@
 name: craftista_$(serviceName)_$(Date:yyyyMMdd)_$(Rev:.r)
 
 trigger:
-- main
+  branches:
+    include:
+      - main
+  paths:
+    include:
+      - voting/**
+
+pr: none
 
 resources:
   repositories:


### PR DESCRIPTION
This PR updates the pipeline configuration to ensure that the pipeline is triggered only when changes occur in all of backend servoce directories on the main branch. Key changes include:

Branch Filter: The trigger is now limited to the main branch.
Path Filter: The pipeline will run only if modifications are made within the service/ folder.
PR Trigger Disabled: Pull request triggers have been disabled (pr: none), ensuring that the pipeline does not run on PR events.